### PR TITLE
add about and onboarding pages

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,0 +1,6 @@
+The [Common Fund Data Ecosystem (CFDE) Coordination Center (CC)](https://commonfund.nih.gov/dataecosystem/coordinatingcenter) is a NIH Common Fund effort to identify and solve issues that inhibit data access and reuse across [NIH Common Fund](https://commonfund.nih.gov/) programs. The Ecosystem is the Coordination Center plus all of the Common Fund Programs who participate. The ultimate goal of the CFDE is for the data to be more usable and useful both within a program’s own data and among datasets from multiple programs. By connecting the data and making them more accessible, the CFDE aims to enable novel scientific research that was not possible before, including hypothesis generation, discovery, and validation.
+
+If you are a member of the CFDE, please login to access private, member-only resources. 
+
+If you would like to become a member, please read the [onboarding documentation](https://www.nih-cfde.org/onboarding/). 
+

--- a/onboarding.md
+++ b/onboarding.md
@@ -1,0 +1,71 @@
+# Onboarding
+
+CFDE members use a number of services to communicate and share files:
+
+  -   Github: Code sharing, organization and deliverables tracking
+  -   groups.io: mailing lists
+  -   Google Drive Teams: file sharing
+  -   Slack: Group chat, forum and instant private messaging
+
+To gain access to these resources, please complete the following steps. Invitations should be received within 2 business days and must be accepted within 5 business days. 
+
+## Complete these four steps:
+
+1. Fill out [this form](https://forms.gle/wsBAYevSQNVfG5eF9).
+2. Accept an invitation to join the cfdeworkspace.slack.com on Slack
+3. Accept an join nih-cfde on GitHub
+4. Read the confirmation emails for our mailing lists and google drive. If you did not receive these emails, please check your spam folder.
+
+By the end of this onboarding process, you should have access to the [CFDE Github](https://github.com/nih-cfde), [mailing list](https://cfdepublic.groups.io/g/CFDEPublicMain), shared Google drive, and slack. Until you have completed onboarding, you will not be able to view some links.
+
+You can see the status of your onboarding progress by finding your name in the [Onboarding Responses Google Sheet](https://docs.google.com/spreadsheets/d/16JcTqlkCRPqrSnykqshrVM2XLf_3HJJiPpAb7qBaOug/edit?usp=sharing).
+
+## Fixes to Access Problems
+
+### GitHub
+
+If you cannot find your GitHub invitation, follow this link to accept on the web: [https://github.com/nih-cfde](https://github.com/nih-cfde)
+
+For help configuring your GitHub notifications and other settings see the [GitHub Help](https://github.com/nih-cfde/organization/blob/master/CommunicationManagementHelp.md#github-help) section of the CFDE Communication Management Overview
+
+For help with how to interact with GitHub (e.g. how to submit a pull request) see our [GitHub User Guide](https://github.com/nih-cfde/organization/blob/master/projectmanagement/GitHubUsage.md)
+
+Before you start contributing on GitHub, you may want to learn about [Markdown](https://github.com/nih-cfde/organization/blob/master/projectmanagement/MarkdownHelp.md).
+
+### groups<span>.io</span>
+
+
+You may need to add `CFDE@groups.io` to your safe sender list in your email client’s contacts
+to reliably receive mailing list emails.
+
+For help configuring your groups.io mailing frequency and other settings see the [groups.io Help](https://github.com/nih-cfde/organization/blob/master/CommunicationManagementHelp.md#groupsio-help) sections of the Communication Management Overview
+
+### Google Drive
+
+You must be logged into Google Drive using the email you specified in your onboarding form. You will have access to two different CFDE drives.
+
+ - [CFDE Admin](https://drive.google.com/drive/u/0/folders/0AIspdLMpflayUk9PVA): Everyone has view access to this drive. It contains files related to maintaining
+ the CFDE infrastructure and files that need to be locked from direct editing such as the contact
+ list created by the onboarding form
+ - [CFDE Everyone](https://drive.google.com/drive/u/0/folders/0ALAyQumxL5IgUk9PVA): Everyone has edit access to this drive. It contains the bulk of CFDE files and
+ is the main place for collaboration
+
+On the left side of the screen, you should see a button for Team Drives. You may need to click on the small arrow to see the list of drives you have access to.
+
+If you have trouble accessing drives, or believe you have been assigned the wrong permissions,
+please email the [Help Desk](mailto:support@cfde.atlassian.net)
+
+For help configuring your Google Drive notifications and other settings see the [Google Drive Help](https://github.com/nih-cfde/organization/blob/master/CommunicationManagementHelp.md#google-drive-help) section of the Communication Management
+Overview
+
+### Slack
+
+
+If you cannot find your Slack invitation, follow this link to accept it on the web: [https://slack.com/signin](https://slack.com/signin)
+
+Our workspace is `cfdeworkspace`
+
+For help configuring your Slack notifications and other settings see the [Slack Help](https://github.com/nih-cfde/organization/blob/master/CommunicationManagementHelp.md#slack-help) section in Communication Management Overview
+
+
+If you did not find a solution to your problem on this page, please check the [Communication Management Help Page](https://github.com/nih-cfde/organization/blob/master/CommunicationManagementHelp.md) or email the [Help Desk](mailto:support@cfde.atlassian.net)


### PR DESCRIPTION
This adds 2 new pages to the public website. 
- The about page should be linked to the about tab that already exists in the navigation bar. 
- The onboarding page should be a sub-heading under about (with contact, contributors, and resources).


